### PR TITLE
Fix openvino int8 tests

### DIFF
--- a/backends/openvino/test/tester/tester.py
+++ b/backends/openvino/test/tester/tester.py
@@ -39,6 +39,7 @@ class Quantize(BaseStages.Quantize):
             calibrate=calibrate,
             calibration_samples=calibration_samples,
             is_qat=is_qat,
+            fold_quantize=False,
         )
 
 

--- a/backends/test/harness/stages/quantize.py
+++ b/backends/test/harness/stages/quantize.py
@@ -28,11 +28,13 @@ class Quantize(Stage):
         calibration_samples: Optional[Sequence[Any]] = None,
         is_qat: Optional[bool] = False,
         set_global: bool = True,
+        fold_quantize: bool = True
     ):
         self.quantizer = quantizer
         self.quantization_config = quantization_config
         self.calibrate = calibrate
         self.calibration_samples = calibration_samples
+        self.fold_quantize = fold_quantize
 
         if self.quantization_config is not None and set_global:
             self.quantizer.set_global(self.quantization_config)
@@ -66,7 +68,7 @@ class Quantize(Stage):
             else:
                 prepared(*inputs)
 
-        converted = convert_pt2e(prepared)
+        converted = convert_pt2e(prepared, fold_quantize=self.fold_quantize)
         DuplicateDynamicQuantChainPass()(converted)
 
         self.converted_graph = converted


### PR DESCRIPTION
### Summary
```python
convert_pt2e(prepared, fold_quantize=False)
```
 is fowrarded in the harness int8 OpenVINO tests to enable them